### PR TITLE
Improve torrent search for anime episodes

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 	"time"
 
-	gintemplate "github.com/foolin/gin-template"
+	"github.com/foolin/gin-template"
 	"github.com/gin-contrib/static"
 	"github.com/gin-gonic/gin"
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/macarrie/flemzerd/configuration"
 	notifier_helper "github.com/macarrie/flemzerd/helpers/notifiers"
@@ -113,6 +113,7 @@ func initRouter() {
 			tvshowsRoute.PUT("/details/:id", updateShow)
 			tvshowsRoute.PUT("/details/:id/custom_title", changeTvshowCustomTitle)
 			tvshowsRoute.PUT("/details/:id/use_default_title", useTvshowDefaultTitle)
+			tvshowsRoute.PUT("/details/:id/change_anime_state", changeTvshowAnimeState)
 			tvshowsRoute.GET("/details/:id/seasons/:season_nb", getSeasonDetails)
 			tvshowsRoute.POST("/details/:id/seasons/:season_nb/download", downloadSeason)
 			tvshowsRoute.PUT("/details/:id/seasons/:season_nb/download_state", changeSeasonDownloadedState)

--- a/server/tvshows.go
+++ b/server/tvshows.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	downloader "github.com/macarrie/flemzerd/downloaders"
+	"github.com/macarrie/flemzerd/downloaders"
 	log "github.com/macarrie/flemzerd/logging"
-	provider "github.com/macarrie/flemzerd/providers"
+	"github.com/macarrie/flemzerd/providers"
 	"github.com/macarrie/flemzerd/scheduler"
 	"github.com/macarrie/flemzerd/stats"
 
@@ -109,6 +109,24 @@ func useTvshowDefaultTitle(c *gin.Context) {
 	c.BindJSON(&showFromRequest)
 
 	tvshow.UseDefaultTitle = showFromRequest.UseDefaultTitle
+	db.Client.Save(&tvshow)
+
+	c.JSON(http.StatusOK, tvshow)
+}
+
+func changeTvshowAnimeState(c *gin.Context) {
+	id := c.Param("id")
+	var tvshow TvShow
+	req := db.Client.Find(&tvshow, id)
+	if req.RecordNotFound() {
+		c.JSON(http.StatusNotFound, gin.H{})
+		return
+	}
+
+	var showFromRequest TvShow
+	c.BindJSON(&showFromRequest)
+
+	tvshow.IsAnime = showFromRequest.IsAnime
 	db.Client.Save(&tvshow)
 
 	c.JSON(http.StatusOK, tvshow)

--- a/server/ui/src/static/js/controllers/tvshow_controller.js
+++ b/server/ui/src/static/js/controllers/tvshow_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from "stimulus"
+import {Controller} from "stimulus"
 
 export default class extends Controller {
     static get targets() {
@@ -67,4 +67,30 @@ export default class extends Controller {
         });
     }
 
+    treatAsRegularShow() {
+        this.changeAnimeState(false);
+    }
+
+    treatAsAnime() {
+        this.changeAnimeState(true);
+    }
+
+    changeAnimeState(state) {
+        fetch('/api/v1/tvshows/details/' + this.showId + '/change_anime_state', {
+            method: "PUT",
+            body: JSON.stringify({
+                IsAnime: state,
+            })
+        }).then(response => {
+            Turbolinks.visit(window.location, {action: "replace"});
+        }).catch(response => {
+            UIkit.notification({
+                message: 'Could not change anime status for show (error during request)',
+                status: 'danger',
+                pos: 'top-right',
+                timeout: 5000
+            });
+            console.log("Request error: ", response);
+        });
+    }
 }

--- a/server/ui/src/templates/partials/media_details_action_bar.tpl
+++ b/server/ui/src/templates/partials/media_details_action_bar.tpl
@@ -52,6 +52,24 @@
                     {{ end }}
                 {{ end }}
 
+                {{ if and (eq .type "tvshow") (not .item.DeletedAt) }}
+                    {{ if .item.IsAnime }}
+                    <a data-controller="{{ .type }}"
+                       data-action="click->{{ .type }}#treatAsRegularShow"
+                       data-{{ .type }}-id="{{ .item.ID }}">
+                        <span class="uk-icon uk-icon-link" uk-icon="icon: world; ratio: 0.75"></span>
+                        Treat as regular show
+                    </a>
+                    {{ else }}
+                    <a data-controller="{{ .type }}"
+                       data-action="click->{{ .type }}#treatAsAnime"
+                       data-{{ .type }}-id="{{ .item.ID }}">
+                        <span class="uk-icon uk-icon-link" uk-icon="icon: world; ratio: 0.75"></span>
+                        Treat as anime
+                    </a>
+                    {{ end }}
+                {{ end }}
+
                 {{ if .item.DeletedAt }}
                 <a (click)="restoreMovie(movie)"
                    data-controller="{{ .type }}"


### PR DESCRIPTION
Fixes #40 

* Do not look for torrents using anime numbering when episode absolute number number is unknown
* Added button to change tvshow's IsAnime boolean